### PR TITLE
docs: update class names on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ Part of [Karr Examples](https://github.com/lewagon/karr-examples)
 A simple app to demonstrate the MVC pattern with a command line app.
 
 ```bash
-$ ruby start.rb
+$ ruby lib/app.rb
 ```
 
 Then hit `Ctrl-C` to quit the program. You'll lose all your todos!
 
 #### Architecture
 
-- **Model**: `TodoItem`
-- **View**: `Display`
-- **Controller**: `Controller`
+- **Model**: `Task`
+- **View**: `TasksView`
+- **Controller**: `TasksController`
 
-We fake the database with `TodoRepository` and the browser with `InfiniteLoop`.
+We fake the database with `TaskRepository` and the browser with `Router`.


### PR DESCRIPTION
The README here has outdated file/class names. They don't match what's in the lecture, so I've updated them.